### PR TITLE
🐛 Issue/46 - adds spacing between tags on projects page

### DIFF
--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -437,6 +437,7 @@
       flex-wrap: wrap;
       justify-content: center;
       align-items: center;
+      gap: 0.5rem;
       max-width: 90%;
       margin: 0.5rem auto;
 


### PR DESCRIPTION
Resolves https://github.com/iamthe-Wraith/jakelundberg.dev-behind-the-scenes/issues/46

## 🚧 What Changed
adds spacing between tags on the projects page.