### PR TITLE
removes the scrollbar from project details

### DIFF
--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -237,7 +237,7 @@
 				</div>
 			</div>
 
-			<div class="details">
+			<div class="details no-scrollbar">
 				{#if selectedProject && selectedProjectVisible}
 					<div
 						class="project"


### PR DESCRIPTION
Resolves https://github.com/iamthe-Wraith/jakelundberg.dev-behind-the-scenes/issues/43

## 🚧 What Changed
adds `no-scrollbar` class to the project details container to hide the scrollbar.

