### PR TITLE
fixes main menu visibility on mobile

### DIFF
--- a/src/lib/components/MainMenu/MainMenu.svelte
+++ b/src/lib/components/MainMenu/MainMenu.svelte
@@ -227,7 +227,7 @@
 		top: 50%;
 		left: 50%;
 		width: 96vw;
-		height: 98vh;
+		height: 90vh;
 		z-index: 1001;
 		transform: translate(-50%, -50%);
 


### PR DESCRIPTION
Resolves https://github.com/iamthe-Wraith/jakelundberg.dev-behind-the-scenes/issues/67

## 🚧 What Changed
reduces height of main menu on mobile to 90vh so entire modal can be viewed on iphone
