### PR TITLE
prevents camera movement on mobile for scenes

### DIFF
--- a/src/lib/components/scenes/Cemetery/Cemetery.svelte
+++ b/src/lib/components/scenes/Cemetery/Cemetery.svelte
@@ -368,7 +368,8 @@
 			spotLight.position.y + mouse.y * 0.8,
 			spotLight.position.z - 1
 		);
-		camera.lookAt(mouse.x * viewabilityThreshold, mouse.y * viewabilityThreshold, 0);
+		if (rect.width >= 768)
+			camera.lookAt(mouse.x * viewabilityThreshold, mouse.y * viewabilityThreshold, 0);
 	}
 
 	function render() {

--- a/src/lib/components/scenes/Forest.svelte
+++ b/src/lib/components/scenes/Forest.svelte
@@ -112,7 +112,8 @@
 		stats?.update();
 
 		if (!$mainMenu.isOpen) {
-			camera.lookAt(mouse.x * viewabilityThreshold, mouse.y * viewabilityThreshold, 0);
+			if (rect.width >= 768)
+				camera.lookAt(mouse.x * viewabilityThreshold, mouse.y * viewabilityThreshold, 0);
 
 			animateTorch();
 		}


### PR DESCRIPTION
Resolves https://github.com/iamthe-Wraith/jakelundberg.dev-behind-the-scenes/issues/8

## 🚧 What Changed
prevents the call to `camera.lookAt` when the screen width is < 768.