### PR TITLE
fixes mismatched font-sizes of nav items and other nav items

### DIFF
--- a/src/lib/components/Nav/Nav.svelte
+++ b/src/lib/components/Nav/Nav.svelte
@@ -444,6 +444,9 @@
 		width: unset;
 		margin: 0;
 		padding: 0.5rem 0;
+		font-family: var(--font-primary);
+		font-size: 0.9rem;
+		font-weight: 400;
 		background: none;
 		border: none;
 		outline: none;
@@ -455,6 +458,7 @@
 			width: 50px;
 			height: 50px;
 			margin-left: 1rem;
+			font-size: 2rem;
 		}
 	}
 


### PR DESCRIPTION
Resolves https://github.com/iamthe-Wraith/jakelundberg.dev-behind-the-scenes/issues/73

## 🚧 What Changed
sets the `font-family`, `font-size`, and `font-weight` of the "other" nav items to match the "regular" nav items.