### PR TITLE
adjusts tracesSampleRate to 25%

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -9,7 +9,7 @@ const errorHandler = (({ error, event }) => {
 Sentry.init({
 	dsn: PUBLIC_SENTRY_DSN,
 	environment: PUBLIC_APP_ENV,
-	tracesSampleRate: 1.0,
+	tracesSampleRate: 0.25,
 	replaysSessionSampleRate: 0.1,
 	replaysOnErrorSampleRate: 1.0,
 	integrations: [new Sentry.Replay()]

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -9,7 +9,7 @@ const errorHandler = (({ error, event }) => {
 
 Sentry.init({
 	dsn: PUBLIC_SENTRY_DSN,
-	tracesSampleRate: 1.0
+	tracesSampleRate: 0.25
 });
 
 import { handleErrorWithSentry } from '@sentry/sveltekit';


### PR DESCRIPTION
## 🚧 What Changed
Changes Sentry `tracesSampleRate` from 1.0 (100%) to 0.25 (25%).
